### PR TITLE
Add teacher markers and docs

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -213,6 +213,8 @@ function fetchAndCacheTodayLessons(dateOverride) {
     const description = event.getDescription() || '';
     const hasEvaluationReady = description.includes('#evaluationReady');
     const hasEvaluationDue = description.includes('#evaluationDue');
+    const teacherMatch = description.match(/#teacher(\w+)/i);
+    const teacher = teacherMatch ? teacherMatch[1] : '';
     
     // Change event color based on evaluation tags
     if (hasEvaluationReady) {
@@ -249,7 +251,8 @@ function fetchAndCacheTodayLessons(dateOverride) {
         lessonHistory: false,
         evaluationReady: hasEvaluationReady,
         evaluationDue: hasEvaluationDue,
-        isOnline:      isOnline
+        isOnline:      isOnline,
+        teacher:       teacher
       });
     });
   });
@@ -269,13 +272,17 @@ function fetchAndCacheTodayLessons(dateOverride) {
         pdfUpload:     item.pdfUpload,
         lessonHistory: item.lessonHistory,
         evaluationReady: item.evaluationReady,
-        evaluationDue: item.evaluationDue
+        evaluationDue: item.evaluationDue,
+        teacher:       item.teacher
       };
     } else {
       grouped[item.eventID].studentNames.push(item.studentName);
       // If any student has evaluation tags, mark the event accordingly
       if (item.evaluationReady) grouped[item.eventID].evaluationReady = true;
       if (item.evaluationDue) grouped[item.eventID].evaluationDue = true;
+      if (!grouped[item.eventID].teacher && item.teacher) {
+        grouped[item.eventID].teacher = item.teacher;
+      }
     }
   });
   const lessons = Object.values(grouped);
@@ -302,7 +309,8 @@ function fetchAndCacheTodayLessons(dateOverride) {
 
   const headers = [
     'eventID', 'eventName', 'Start', 'End',
-    'folderName', 'studentNames', 'pdfUpload', 'lessonHistory', 'evaluationReady', 'evaluationDue', 'isOnline'
+    'folderName', 'studentNames', 'pdfUpload', 'lessonHistory',
+    'evaluationReady', 'evaluationDue', 'isOnline', 'teacher'
   ];
   tgt.getRange(1, 1, 1, headers.length).setValues([headers]);
 
@@ -318,7 +326,8 @@ function fetchAndCacheTodayLessons(dateOverride) {
       l.lessonHistory,
       l.evaluationReady || false,
       l.evaluationDue || false,
-      l.isOnline || false
+      l.isOnline || false,
+      l.teacher || ''
     ]);
     tgt.getRange(2, 1, out.length, headers.length).setValues(out);
     Logger.log('Wrote %s lessons to sheet', out.length);

--- a/Index.html
+++ b/Index.html
@@ -496,9 +496,22 @@
       cursor: pointer;
       z-index: 10;
     }
-    
+
     .evaluation-btn:hover {
       background: #e55a2b;
+    }
+
+    /* Teacher Marker */
+    .teacher {
+      position: absolute;
+      top: 4px;
+      right: 120px;
+      background: #673ab7;
+      color: white;
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+      z-index: 10;
     }
 
     /* Online Marker */
@@ -621,7 +634,8 @@
 
     /* 2) Child markers become static (in the flex flow) */
     .marker-container .online-marker,
-    .marker-container .evaluation-btn {
+    .marker-container .evaluation-btn,
+    .marker-container .teacher {
       position: static;   /* <-- remove absolute positioning */
       top: auto;          /* <-- reset any old top/right */
       right: auto;
@@ -991,6 +1005,14 @@
             openEvaluationModal(e);
           };
           markerContainer.appendChild(evalBtn);
+        }
+
+        // Add teacher marker if teacher tag exists
+        if (e.teacher) {
+          const teacherDiv = document.createElement('div');
+          teacherDiv.className = 'teacher';
+          teacherDiv.textContent = e.teacher;
+          markerContainer.appendChild(teacherDiv);
         }
 
         // Only append the container if it has children

--- a/TEACHER README.md
+++ b/TEACHER README.md
@@ -162,19 +162,36 @@ This application provides a comprehensive dashboard for teachers to:
 ### Core Functions (`Code.js`)
 - `doGet()`: Web app entry point
 - `getEventsJson()`: Returns lesson data for the dashboard
-- `fetchAndCacheTodayLessons()`: Fetches and processes today's lessons
-- `markPdfUploaded()`: Updates PDF upload status
-- `createFoldersForStudents()`: Creates student folder structure
-- `changeEventColor()`: Updates calendar event colors based on evaluation tags
+- `getLessonsTodayStatuses()`: Reads PDF and history status flags
+- `markPdfUploaded(eventID, flag)`: Updates PDF upload status
+- `isValidLessonEvent_(event)`: Filters out cancelled lessons by color
+- `fetchAndCacheTodayLessons([date])`: Fetches events and updates the sheet
+- `determineLessonTypeAndPrefix(eventName)`: Detects lesson type
+- `incrementLessonTypeID(type)`: Increments ID counters
+- `createFoldersForStudents()`: Placeholder for folder creation (currently commented out)
+- `manual()`: Debug helper to refresh a specific date
+- `createDemoLessonFolder(eventID, eventName)`: Creates demo lesson folders
+- `getStudentLinks(studentName)`: Returns note/history URLs
+- `extractStudentNameFromDemo(eventName)`: Parses names from demo titles
+- `changeEventColor(eventID, color)`: Updates calendar event colors
+- `getStudentNamesByFolder(folderName)`: Lists students by folder
+- `getStudentEvaluations(studentName)`: Retrieves evaluation history
 
 ### Helper Functions (`Helper.js`)
-- `uploadStudentPDF()`: Converts and uploads lesson notes
-- `addLessonHistoryEntry()`: Records lesson progress
+- `uploadStudentPDF(data)`: Converts and uploads lesson notes
+- `addLessonHistoryEntry(data)`: Records lesson progress
+- `_updateStatusInTodaySheet(folderName, date, columnName)`: Flags status in sheet
+- `findStudentFolder(name)`: Finds a student folder
+- `findFolderInFolder(parent, name)`: Finds a subfolder
+- `findFileInFolder(parent, name)`: Finds a file
+- `_appendLessonHistoryRow(...)`: Writes a row to the history sheet
 - `getStudentFolders()`: Retrieves student folder list
 - `getTeacherList()`: Gets available teachers
-- `getStudentLinks()`: Returns direct URLs to student files
-- `generateEvaluationPDF()`: Creates evaluation PDF documents
-- `createEvaluationContent()`: Formats evaluation data for PDF generation
+- `getFoldersAndTeachers()`: Bundles folder and teacher data
+- `formatStudentNames(students)`: Formats names for folder creation
+- `generateEvaluationPDF(data)`: Creates evaluation PDF documents
+- `createEvaluationContent(data)`: Formats evaluation data for PDF generation
+- `getStudentNamesByFolder(folderName)`: Finds student names by folder
 
 ## Calendar Event Format
 
@@ -193,6 +210,11 @@ This application provides a comprehensive dashboard for teachers to:
 - **Evaluation Due**: Add `#evaluationDue` to event description
 - **Automatic Color Coding**: Green for ready, red for due
 - **Evaluation Button**: Orange button appears on events with `#evaluationDue` tag
+
+### Teacher Tags
+- **Assign Teacher**: Add `#teacherName` to event description
+- **Example**: `#teacherKhacey`, `#teacherAna`, `#teacherSham`
+- **Dashboard Display**: Teacher name appears as a purple marker on the lesson card
 
 ## Folder Structure
 
@@ -267,8 +289,8 @@ Google Drive/
 
 ---
 
-**Version**: 1.2  
-**Last Updated**: 2024  
-**Timezone**: Asia/Tokyo  
-**Language**: English/Japanese (mixed content)  
+**Version**: 1.3
+**Last Updated**: 2025
+**Timezone**: Asia/Tokyo
+**Language**: English/Japanese (mixed content)
 **Clasp Project ID**: 1GgbhvcVRx27p3fCbah5wduyzczrzbzaurgK15oeYdn5bjh8XxOpDCRSm 


### PR DESCRIPTION
## Summary
- parse teacher tags from event descriptions
- show teacher markers in dashboard
- update README with teacher tag instructions

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6881ddbee92483208f8c194d54e4741a